### PR TITLE
Add JetBrains IDE files to .gitignore

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,3 +2,6 @@
 /target
 # This file contains environment-specific configuration like linker settings
 .cargo/config.toml
+
+# JetBrains IDEs
+.idea/

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # Spacetime ignore
 /.spacetime
+
+# JetBrains IDEs
+.idea/

--- a/spacetime_physics/.gitignore
+++ b/spacetime_physics/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # Spacetime ignore
 /.spacetime
+
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
## Description

Just adds gitignore entries for the `.idea/` directory which is created by JetBrains IDEs.